### PR TITLE
Do not let the environment bother you.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The ECCV workshop short abstract version of the paper can be found here:
 ## Usage
 - To run a simple version of PReMVOS with pre-trained weights already finetuned on the first frame annotations of YouTube-VOS and DAVIS (this version was used to win the ECCV YouTube-VOS challenge), see `simple_run.sh` . By docker:
     - docker pull mayorx/premvos
-    - docker run -it --gpus all -v \`pwd\`:/tmp/PReMVOS-master/output --rm mayorx/premvos /bin/bash
+    - docker run -it --gpus all -v \`pwd\`:/tmp/PReMVOS-master/output/final --rm mayorx/premvos /bin/bash
     - sh simple_run.sh
 - To test if you have gotten it working, the result numbers should be:
 Mean J: 0.7363.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,16 @@ The ECCV workshop short abstract version of the paper can be found here:
 - CUDA 9.0
 - cudnn 7
 - COCO API for Python 3
+- Or you can simplely test it on a [docker image](https://hub.docker.com/r/mayorx/premvos)
+  - docker version >= 19.03
+  - nvidia-docker would be required.
 
 
 ## Usage
-- To run a simple version of PReMVOS with pre-trained weights already finetuned on the first frame annotations of YouTube-VOS and DAVIS (this version was used to win the ECCV YouTube-VOS challenge), see `simple_run.sh` 
+- To run a simple version of PReMVOS with pre-trained weights already finetuned on the first frame annotations of YouTube-VOS and DAVIS (this version was used to win the ECCV YouTube-VOS challenge), see `simple_run.sh` . By docker:
+    - docker pull mayorx/premvos
+    - docker run -it --gpus all -v \`pwd\`:/tmp/PReMVOS-master/output --rm mayorx/premvos /bin/bash
+    - sh simple_run.sh
 - To test if you have gotten it working, the result numbers should be:
 Mean J: 0.7363.
 Mean F: 0.80044.

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ The ECCV workshop short abstract version of the paper can be found here:
 - CUDA 9.0
 - cudnn 7
 - COCO API for Python 3
-- Or you can simplely test it on a [docker image](https://hub.docker.com/r/mayorx/premvos)
+- Or you can simplely test it on a [docker image](https://hub.docker.com/r/mayorx/premvos-testonly)
   - docker version >= 19.03
   - nvidia-docker would be required.
 
 
 ## Usage
 - To run a simple version of PReMVOS with pre-trained weights already finetuned on the first frame annotations of YouTube-VOS and DAVIS (this version was used to win the ECCV YouTube-VOS challenge), see `simple_run.sh` . By docker:
-    - docker pull mayorx/premvos
-    - docker run -it --gpus all -v \`pwd\`:/tmp/PReMVOS-master/output/final --rm mayorx/premvos /bin/bash
+    - docker pull mayorx/premvos-testonly
+    - docker run -it --gpus all -v \`PATH_TO_PReMVOS_FOLDER\`:/root/PReMVOS-master --rm mayorx/premvos-testonly 
     - sh simple_run.sh
 - To test if you have gotten it working, the result numbers should be:
 Mean J: 0.7363.


### PR DESCRIPTION

* The Evaluating results on DAVIS2017 val dataset:
```
+--------+--------+----------+---------+--------+----------+---------+
| Method | J_mean | J_recall | J_decay | F_mean | F_recall | F_decay |
+--------+--------+----------+---------+--------+----------+---------+
|        | 0.736  |  0.822   |  0.086  | 0.800  |  0.872   |  0.112  |
+--------+--------+----------+---------+--------+----------+---------+
```

* some details:
```
  F: {decay: 0.11197381588794149, mean: 0.800432921693015, recall: 0.8720315631476686}
  J: {decay: 0.08576760375105791, mean: 0.7362924131132025, recall: 0.82213337387194}
```

```
bike-packing:
    F:
      decay: [0.055391204193174115, 0.3334787620123566]
      mean: [0.7455431766988955, 0.6437902017344503]
      raw:
      - [.nan, 0.9702132784059692, 0.9695046217473648, 0.9599861945642229, 0.904163796100894,
        0.9416088417018552, 0.9123938158355934, 0.8521367419956946, 0.8600358389178661,
        0.7791194998850051, 0.8975552764204303, 0.8978591219487625, 0.8154646549522669,
        0.9059104835512501, 0.7013986454085092, 0.6083674195215554, 0.6363124845265693,
        0.6193867242886717, 0.5464336409361495, 0.5910454055818702, 0.7285970383337952,
        0.744277928050623, 0.7782631714232869, 0.7713530352963791, 0.7035546610844013,
        0.6954445083020723, 0.7016666145523904, 0.6848221002506274, 0.7218913383723443,
        0.6980589737215682, 0.6552023845498366, 0.6565690623686292, 0.6150006624159016,
        0.6598662363460844, 0.6844464006501821, 0.6936866367950126, 0.7302366085450578,
        0.6475530615760406, 0.6987002080537761, 0.696171552356148, 0.6362408443576285,
        0.7048536171256012, 0.6891822599957235, 0.7139477876226623, 0.6588857003025308,
        0.6941658038275687, 0.7687587141907335, 0.7455608202026102, 0.676534614814838,
        0.646688935708915, 0.6671061886238829, 0.5772188377225977, 0.7005753252463952,
        0.5229977213076884, 0.5191689193188769, 0.5252406414263705, 0.8515561357999573,
        0.8675111064984761, 0.8159688919558125, 0.8181820751783342, 0.8241217833026319,
        0.8421550606835806, 0.811542028845231, 0.8500738519261308, 0.8380510874591229,
        0.894085811840567, 0.8763344767299281, 0.8804251274769305, .nan]
      - [.nan, 1.0, 0.9963241295272994, 0.996716106094051, 0.9692370377915861, 0.9961734947962789,
        0.9824800910125142, 0.9842167255594818, 0.9677181797414995, 0.9944013781223084,
        0.9950339656699507, 0.9942854659626708, 0.9672406267403181, 0.9825825150583369,
        0.9832120469526529, 0.9863911610468138, 0.9602009801021965, 0.7856125625560854,
        0.795157253973622, 0.7776424047731496, 0.6089224675743196, 0.5679595093000066,
        0.602501856400297, 0.6047426480702044, 0.575207668467294, 0.5551374765492076,
        0.5398806893504199, 0.5212784914040395, 0.5203622552695247, 0.5531654483074161,
        0.44863675916078505, 0.46846500407267805, 0.4669598874032372, 0.4733446794164288,
        0.45525587064126727, 0.4651719668874583, 0.4354440598690186, 0.397554399285798,
        0.35655051304007085, 0.3608997143547992, 0.3572008764135007, 0.3988555777842533,
        0.3923047101771842, 0.3877600165026021, 0.381450147189191, 0.38142816310658956,
        0.40553978335920676, 0.45448887855564696, 0.38930115877434546, 0.3777336116288333,
        0.411134098175663, 0.5396123945501523, 0.5538287069974873, 0.6917151685591308,
        0.495297282418129, 0.38454094153474194, 0.5319075798531144, 0.6056906403769052,
        0.6905441311671756, 0.7010009209175166, 0.8110687348109276, 0.6976864802564441,
        0.7141445987937224, 0.7353768843200951, 0.7046632124352332, 0.61595677258498,
        0.6138375054317035, 0.6178070492286062, .nan]
      recall: [1.0, 0.6567164179104478]
      std: [0.11529672281357806, 0.22293081610044127]
    J:
      decay: [0.07525003734528668, 0.17383976823631786]
      mean: [0.6306314428828076, 0.7247685027428918]
      raw:
      - [.nan, 0.8169645422676858, 0.8049341358164888, 0.7953459957791847, 0.767764537128986,
        0.8154179585202131, 0.7777008727053867, 0.7641904420120821, 0.7661821417976862,
        0.7421868680059324, 0.775990875392073, 0.7092122830440587, 0.670211146628395,
        0.7628711488151177, 0.6821587661250869, 0.6470884311599814, 0.6459157286279282,
        0.6117556300626057, 0.44906315367840133, 0.45742259073494845, 0.5984440012802521,
        0.5855787560896757, 0.5559396741713841, 0.5775747526546389, 0.5240971131779201,
        0.5518586699579524, 0.5579530183303768, 0.5759242285365108, 0.6205798906650059,
        0.5761572166066548, 0.5466353175137498, 0.5523237335575217, 0.5362593535903967,
        0.5412606797823704, 0.5807250983138501, 0.6066003678223554, 0.6057842803674719,
        0.5447604775260989, 0.5896485762693338, 0.6108257833689191, 0.5608017314773974,
        0.6125715699839144, 0.5998584781839555, 0.6203238220712132, 0.5436828307936541,
        0.5436687600408938, 0.5530945531159428, 0.5445260386769858, 0.5637684130377486,
        0.5695290966264218, 0.6359665995338417, 0.4719949216929013, 0.5845921450151057,
        0.29809262657015545, 0.14392935301914125, 0.20635763151686717, 0.8000710948608571,
        0.7347835916501294, 0.787966826897681, 0.7384622784444819, 0.7911158656172792,
        0.7952489837398374, 0.7743917988473504, 0.761804292469989, 0.7648692376421724,
        0.8063073250408342, 0.7799179847685999, 0.7633005839280749, .nan]
      - [.nan, 0.9715905163475496, 0.9733214344425918, 0.9666597014232314, 0.9516630611141157,
        0.9602723925291691, 0.9570531318961127, 0.9581136557817742, 0.9342929788384152,
        0.9578988529718456, 0.9501695938626556, 0.9495678939268379, 0.9380071568973338,
        0.9451894350896252, 0.9396498561052488, 0.9479761451592438, 0.926689841637698,
        0.7637826872060102, 0.7864931579073502, 0.7618659872343779, 0.6998078081523765,
        0.6705255579553636, 0.6796995929599267, 0.6937106735871488, 0.6716284950716974,
        0.6587713231904103, 0.5753113405619948, 0.6231825872501505, 0.6579479151842892,
        0.6447926684392148, 0.5186810035842294, 0.5249361897387365, 0.5334754797441364,
        0.5352720503201421, 0.450054915655186, 0.42201137451433074, 0.4208289656344732,
        0.4077361540424808, 0.48285852245292127, 0.5035911759676224, 0.5536245140635719,
        0.6343171443962462, 0.6222215977744682, 0.6209989692731983, 0.6130581697338658,
        0.6143446507219713, 0.5955793520043932, 0.6387183993510883, 0.6234744881130592,
        0.6126693329892917, 0.6244192185850053, 0.6548015166756945, 0.6649910233393178,
        0.5419995575112466, 0.5959230642774946, 0.6615800066236975, 0.7460520143847397,
        0.7840796552554803, 0.7965994962216625, 0.8040292628024761, 0.8387222270251578,
        0.7822673990361344, 0.8128543271086908, 0.8575217442177933, 0.8631001319286438,
        0.8375257498157352, 0.8180345873899365, 0.830900808775681, .nan]
      recall: [0.9104477611940298, 0.9253731343283582]
      std: [0.13741263665603054, 0.16504603970584664]

 blackswan:
         .......
```

* The running log of `simple_run.sh` is almost 20000 lines..  if you need to check the log , I can upload it to google drive.
